### PR TITLE
Fixed an issue where saved scene lighting would add unintended directional lighting proportionally

### DIFF
--- a/Shared/SceneController.cs
+++ b/Shared/SceneController.cs
@@ -202,7 +202,7 @@ namespace Graphics
             int counter = 0;
 
             List<PerLightSettings> newDirectionalLights = new List<PerLightSettings>(settings.Where(pls => pls.Type == (int)LightType.Directional));
-
+            
             if (settings.Length > 0 && settings[0].HierarchyPath != null)
             {
                 foreach (LightObject light in lightManager.DirectionalLights)
@@ -252,16 +252,21 @@ namespace Graphics
 
             if (!KKAPI.Studio.StudioAPI.InsideStudio && newDirectionalLights.Count > 0)
             {
-                // Add extra lights if requested
+                // Add Directional lights created by Graphics
+                // TODO: Not sure, but getting a string from setting.LightName is not safe. Is it intented?
                 foreach (PerLightSettings setting in newDirectionalLights)
                 {
+                    if (setting.HierarchyPath.ToString().StartsWith("/(Graphics)"))
+                    {
 #if DEBUG
-                    Graphics.Instance.Log.LogInfo($"Adding Additional Light {setting.LightName} {setting.HierarchyPath} {setting.LightId}");
+                        Graphics.Instance.Log.LogInfo($"Adding Graphics Directional Light: {setting.LightName}, {setting.HierarchyPath}, {setting.LightId}.");
 #endif
-
-                    GameObject lightGameObject = new GameObject(setting.LightName);
-                    Light lightComp = lightGameObject.AddComponent<Light>();
-                    lightGameObject.GetComponent<Light>().type = LightType.Directional;
+                        string lightName = setting.HierarchyPath.ToString();
+                        lightName = lightName.Substring(lightName.IndexOf("/") + 1, lightName.LastIndexOf("(") - 1);
+                        GameObject lightGameObject = new GameObject(lightName);
+                        Light lightComp = lightGameObject.AddComponent<Light>();
+                        lightGameObject.GetComponent<Light>().type = LightType.Directional;
+                    }
                 }
                 lightManager.Light();
                 foreach (LightObject light in lightManager.DirectionalLights)


### PR DESCRIPTION
Hello there,

The current 1.8.0 version has a painful map lights setting.

There are many reasons to suffer, but first of all, we fixed one function.

Still don't know why this plugin creates many unnecessary directional lights based on the map's scene.

By accident, the number of those "New Game Object" is the same as the "light" file saved in the mapLightPresets directory.

With this, every time we save the map light to a preset, next time we choke on numerous "New Game Object" instances.

So we manipulate this SceneController to make additional light created by the Graphics plugin with "(Graphics)" prefix only.

It just works as we wanted in the main game, but we didn't test it in the studio.

Unfortunately, when we commit this code, we thought, what if it is given by multiple lights with the same name, hierarchy, and lightId, what will happen?

We don't know that, we just want to follow SEGI's instructions (adding a single directional light) on YouTube, and it's fine now. 

Sincerely,
